### PR TITLE
[Finishes #148191201] Refactor Responses, Sad Path Testing

### DIFF
--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -19,11 +19,25 @@ function createFood(name, calories) {
 }
 
 function updateFood(params, id) {
-  return database.raw(
-    'UPDATE foods SET name=?, calories=? WHERE id=? RETURNING *',
-      [params.name, params.calories, id]).then(function(data) {
-        return data.rows
-      })
+  if (params.name && params.calories) {
+    return database.raw(
+      'UPDATE foods SET name=?, calories=? WHERE id=? RETURNING *',
+        [params.name, params.calories, id]).then(function(data) {
+          return data.rows
+        })
+  } else if (params.name) {
+    return database.raw(
+      'UPDATE foods SET name=? WHERE id=? RETURNING *',
+        [params.name, id]).then(function(data) {
+          return data.rows
+        })
+  } else {
+    return database.raw(
+      'UPDATE foods SET calories=? WHERE id=? RETURNING *',
+        [params.calories, id]).then(function(data) {
+          return data.rows
+        })
+  }
 }
 
 function emptyFoodsTable() {

--- a/server.js
+++ b/server.js
@@ -65,14 +65,14 @@ app.post('/api/v1/foods', function (request, response) {
 app.put('/api/v1/foods/:id', function(request, response){
   const id = request.params.id
   const params = request.body
-  if (params['name'] || params['calories'] && !params['id'] && !params['created_at']) {
+  if ((params['name'] || params['calories']) && !params['id'] && !params['created_at']) {    
     Food.updateFood(params, id)
       .then(function(data){
         if(!data) { response.sendStatus(404) }
         response.json(data)
       })
   } else {
-    return response.sendStatus(422).send({ error: "Your properties are incorrect."})
+    return response.status(422).send({ error: "Your properties are incorrect."})
   }
   
 })

--- a/server.js
+++ b/server.js
@@ -65,12 +65,16 @@ app.post('/api/v1/foods', function (request, response) {
 app.put('/api/v1/foods/:id', function(request, response){
   const id = request.params.id
   const params = request.body
-  Food.updateFood(params, id)
-    .then(function(data){
-      const food = data
-      if(!food) { response.sendStatus(404) }
-      response.json(data)
-    })
+  if (params['name'] || params['calories'] && !params['id'] && !params['created_at']) {
+    Food.updateFood(params, id)
+      .then(function(data){
+        if(!data) { response.sendStatus(404) }
+        response.json(data)
+      })
+  } else {
+    return response.sendStatus(422).send({ error: "Your properties are incorrect."})
+  }
+  
 })
 
 

--- a/server.js
+++ b/server.js
@@ -25,15 +25,21 @@ app.get('/', function(request, response) {
 app.get('/api/v1/foods', function(request, response){
   const id = request.params.id
   Food.findAll()
-  .then( function(data) {
-    const foodData = data
-
-    if (data.rowCount == 0) { return response.sendStatus(404) }
-    const rawFoods = data.rows
-    const foods = rawFoods.map(function (food){
-      return { id: food.id, name: food.name, calories: food.calories, created_at: food.created_at }
+    .then( function(data) {
+      if (data.rowCount == 0) { return response.sendStatus(404) }
+      response.json(data.rows)
     })
-    response.json({foods})
+})
+
+app.get('/api/v1/foods/:id', function(request, response){
+  const id = request.params.id
+  Food.findFood(id)
+  .then(function(data) {
+    const foodData = data
+    
+    if (data.rowCount == 0) { return response.sendStatus(404) }
+    const rawFood = data.rows
+    response.json(rawFood)
   })
 })
 
@@ -51,26 +57,9 @@ app.post('/api/v1/foods', function (request, response) {
   Food.createFood(food.name, food.calories).then(function() {
     Food.findAll().then(function(data){
       if (data.rowCount == 0) { return response.sendStatus(404) }
-      const rawFoods = data.rows
-      const foods = rawFoods.map(function (food){
-        return { id: food.id, name: food.name, calories: food.calories, created_at: food.created_at }
-      })
-      response.json(foods)
+      response.json(data.rows)
     })
   })
 })
-  
-app.get('/api/v1/foods/:id', function(request, response){
-  const id = request.params.id
-  Food.findFood(id)
-    .then(function(data) {
-      const foodData = data
-
-      if (data.rowCount == 0) { return response.sendStatus(404) }
-      const rawFood = data.rows
-      response.json({ rawFood })
-    })
-})
-
 
 module.exports = app

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -224,30 +224,65 @@ describe('server', function() {
         Food.emptyFoodsTable()
           .then(function() { done() })
       })
-
-      it('should update a food', function(done){
+this.timeout(100000)
+      // it('should update both name and calories of a food', function(done){
+      //   const ourRequest = this.request
+      //   const foodParams = {name: 'steak', calories: 400}
+      //   const idToChange = 1
+      // 
+      //   ourRequest.put(`/api/v1/foods/${idToChange}`, {form: foodParams}, function(error, response){
+      //     if (error) { done(error) }
+      //     const parsedFood = JSON.parse(response.body)
+      //     assert.equal(parsedFood[0].id, idToChange)
+      //     assert.equal(parsedFood[0].name, foodParams.name)
+      //     assert.equal(parsedFood[0].calories, foodParams.calories)
+      //     done()
+      //   })
+      // })
+      
+      // it('should update name', function(done){
+      //   const ourRequest = this.request
+      //   const foodParams = {name: 'steak'}
+      // 
+      //   ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
+      //     if (error) { done(error) }
+      //     const parsedFood = JSON.parse(response.body)
+      //     assert.equal(parsedFood[0].id, id)
+      //     assert.equal(parsedFood[0].name, foodParams.name)
+      //     assert.equal(parsedFood[0].calories, 150)
+      //     done()
+      //   })
+      // })
+      
+      // it('should return a 422 if the food is not updated correctly', function(done) {
+      //   const ourRequest = this.request
+      //   const foodParams = {name: 'steak', calormies: 400}
+      // 
+      //   ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
+      //     if (error) { done(error) }
+      //     assert.equal(response.statusCode, 404)
+      //     done()
+      //   })
+      // })
+      
+      it('should return a 422 if there is an attempt to change the id', function(done) {
         const ourRequest = this.request
-        const id = 1
-        const food_params = {name: 'steak', calories: 400}
+        const foodParams = {id: 300, name: 'steak', calories: 400}
 
-        ourRequest.put(`/api/v1/foods/${id}`, {form: food_params}, function(error, response){
+        ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
           if (error) { done(error) }
-          const parsedFood = JSON.parse(response.body)
-          assert.equal(parsedFood[0].id, id)
-          assert.equal(parsedFood[0].name, food_params.name)
-          assert.equal(parsedFood[0].calories, food_params.calories)
+          assert.equal(response.statusCode, 422)
           done()
         })
       })
       
-      it('should return a 200', function(done) {
+      it('should return a 422 if there is an attempt to change the created_at', function(done) {
         const ourRequest = this.request
-        const id = 1
-        const food_params = {name: 'steak', calories: 400}
+        const foodParams = {name: 'steak', calories: 400, created_at: new Date}
 
-        ourRequest.put(`/api/v1/foods/${id}`, {form: food_params}, function(error, response){
+        ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
           if (error) { done(error) }
-          assert.equal(response.statusCode, 200)
+          assert.equal(response.statusCode, 422)
           done()
         })
       })

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -225,45 +225,59 @@ describe('server', function() {
           .then(function() { done() })
       })
 this.timeout(100000)
-      // it('should update both name and calories of a food', function(done){
-      //   const ourRequest = this.request
-      //   const foodParams = {name: 'steak', calories: 400}
-      //   const idToChange = 1
-      // 
-      //   ourRequest.put(`/api/v1/foods/${idToChange}`, {form: foodParams}, function(error, response){
-      //     if (error) { done(error) }
-      //     const parsedFood = JSON.parse(response.body)
-      //     assert.equal(parsedFood[0].id, idToChange)
-      //     assert.equal(parsedFood[0].name, foodParams.name)
-      //     assert.equal(parsedFood[0].calories, foodParams.calories)
-      //     done()
-      //   })
-      // })
+      it('should update both name and calories of a food', function(done){
+        const ourRequest = this.request
+        const foodParams = {name: 'steak', calories: 400}
+        const idToChange = 1
       
-      // it('should update name', function(done){
-      //   const ourRequest = this.request
-      //   const foodParams = {name: 'steak'}
-      // 
-      //   ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
-      //     if (error) { done(error) }
-      //     const parsedFood = JSON.parse(response.body)
-      //     assert.equal(parsedFood[0].id, id)
-      //     assert.equal(parsedFood[0].name, foodParams.name)
-      //     assert.equal(parsedFood[0].calories, 150)
-      //     done()
-      //   })
-      // })
+        ourRequest.put(`/api/v1/foods/${idToChange}`, {form: foodParams}, function(error, response){
+          if (error) { done(error) }
+          const parsedFood = JSON.parse(response.body)
+          assert.equal(parsedFood[0].id, idToChange)
+          assert.equal(parsedFood[0].name, foodParams.name)
+          assert.equal(parsedFood[0].calories, foodParams.calories)
+          done()
+        })
+      })
       
-      // it('should return a 422 if the food is not updated correctly', function(done) {
-      //   const ourRequest = this.request
-      //   const foodParams = {name: 'steak', calormies: 400}
-      // 
-      //   ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
-      //     if (error) { done(error) }
-      //     assert.equal(response.statusCode, 404)
-      //     done()
-      //   })
-      // })
+      it('should update name', function(done){
+        const ourRequest = this.request
+        const foodParams = {name: 'steak'}
+      
+        ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
+          if (error) { done(error) }
+          const parsedFood = JSON.parse(response.body)
+          assert.equal(parsedFood[0].id, 1)
+          assert.equal(parsedFood[0].name, foodParams.name)
+          assert.equal(parsedFood[0].calories, 150)
+          done()
+        })
+      })
+      
+      it('should return only one property updated if the other is not passed correctly', function(done) {
+        const ourRequest = this.request
+        const foodParams = {name: 'steak', calormies: 400}
+      
+        ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
+          if (error) { done(error) }
+          const parsedFood = JSON.parse(response.body)
+          assert.equal(parsedFood[0].id, 1)
+          assert.equal(parsedFood[0].name, foodParams.name)
+          assert.equal(parsedFood[0].calories, 150)
+          done()
+        })
+      })
+      
+      it('should return a 422 if a property is not updated correctly', function(done) {
+        const ourRequest = this.request
+        const foodParams = {calormies: 400}
+      
+        ourRequest.put(`/api/v1/foods/1`, {form: foodParams}, function(error, response){
+          if (error) { done(error) }
+          assert.equal(response.statusCode, 422)
+          done()
+        })
+      })
       
       it('should return a 422 if there is an attempt to change the id', function(done) {
         const ourRequest = this.request


### PR DESCRIPTION
@case-eee @stovermc I added some sad paths for our put request, but not sure it's exactly what we want. If one property is entered correctly, but the other is not (e.g. {name: 'steak', malories: 500}), do we want to update the property that was entered correctly or return an error for the whole request? OR do we want to only accept one property change at a time?